### PR TITLE
Create `BuildTimeComponent` higher lever abstraction

### DIFF
--- a/lib/-private/build-attr.ts
+++ b/lib/-private/build-attr.ts
@@ -22,6 +22,11 @@ export default function buildAttr(name: string, content: CoherzableToAttrValue):
     return b.attr(name, b.text(String(content.value)));
   } else if (content.type === 'NullLiteral' || content.type === 'UndefinedLiteral') {
     return null;
+  } else if (content.type === 'ConcatStatement') {
+    if (content.parts.length === 1) {
+      return buildAttr(name, content.parts[0]);
+    }
+    return b.attr(name, content);
   } else {
     return b.attr(name, content);
   }

--- a/lib/-private/build-attr.ts
+++ b/lib/-private/build-attr.ts
@@ -3,10 +3,12 @@
 import { builders as b, AST } from '@glimmer/syntax';
 
 export type AttrValue = AST.TextNode | AST.MustacheStatement | AST.ConcatStatement;
-export type CoherzableToAttrValue = AttrValue | AST.PathExpression | AST.SubExpression | AST.Literal | string;
+export type CoherzableToAttrValue = AttrValue | AST.PathExpression | AST.SubExpression | AST.Literal | string | undefined;
 
 export default function buildAttr(name: string, content: CoherzableToAttrValue): AST.AttrNode | null {
-  if (typeof content === 'string') {
+  if (content === undefined) {
+    return null;
+  } else if (typeof content === 'string') {
     return b.attr(name, b.text(content));
   } else if (content.type === 'PathExpression') {
     return b.attr(name, b.mustache(content));

--- a/lib/-private/build-time-component.ts
+++ b/lib/-private/build-time-component.ts
@@ -33,6 +33,39 @@ const defaultOptions : BuildTimeComponentOptions = {
   attributeBindings: ['class']
 }
 
+/**
+ * This is supposed to be the main abstraction used by most people to achieve most of their works
+ * Only when they want to do something extra the can override methods and do it themselves.
+ *
+ * It has some basic behaviour by default to remind how "real" ember components work, but very little.
+ * Namely, the `class` property is automatically bound to `class` attribute in the resulting HTMLElement.
+ * Also, if on initialization the user passes `classNames`, the classes in that array will be concatenated
+ * with the value passed to `class`.
+ * The user can also pass default values for the properties the component doesn't receive on invocation.
+ *
+ * That object has two main properties to help working with this abstraction useful.
+ *
+ * - `classNameBindings`: Identical behavior to the one in Ember components
+ * - `attributeBindings`: Almost identical behaviour to the one in Ember components, with one enhancements.
+ *   Some attributes are expected to have regular values (p.e. the `title` attribute must have a string),
+ *   so `{{my-component title=username}}` compiles to `<div title={{username}}></div>`.
+ *   However, there is properties that are expected to be boolean that when converted to attributes
+ *   should have other values. That is why you can pass `attributeBindings: ['isDisabled:disabled:no']`
+ *   You will notice that in regular Ember components, the items in attribute bindings only have one `:`
+ *   dividing propertyName and attributeName. If you put two semicolons dividing the string in three parts
+ *   the third part will be used for the truthy value, generating in the example above `<div disabled={{if disabled 'no'}}></div>`
+ *
+ * More example usages:
+ *
+ * let component = new BuildTimeComponent(node); // creates the component
+ * component.toNode(); // generates the element with the right markup
+ *
+ * let soldier = new BuildTimeComponent(node, {
+ *   classNameBindings: ['active:is-deployed:reservist'],
+ *   attributeBindings: ['title', 'url:href', 'ariaHidden:aria-hidden:true']
+ * });
+ */
+
 export default class BuildTimeComponent {
   node: AST.MustacheStatement
   options: BuildTimeComponentOptions

--- a/lib/-private/build-time-component.ts
+++ b/lib/-private/build-time-component.ts
@@ -10,7 +10,8 @@ export interface BuildTimeComponentOptions {
   classNames: string[]
   ariaHidden: boolean
   title: string | undefined | null
-  ariaLabel: string | undefined | null
+  ariaLabel: string | undefined | null,
+  classNameBindings: string[]
 }
 
 const defaultOptions = {
@@ -18,16 +19,18 @@ const defaultOptions = {
   classNames: [],
   ariaHidden: false,
   title: undefined,
-  ariaLabel: undefined
+  ariaLabel: undefined,
+  classNameBindings: []
 }
 
 export default class BuildTimeComponent {
   node: AST.MustacheStatement
   options: BuildTimeComponentOptions
 
-  constructor(node: AST.MustacheStatement, options: object = {}) {
+  constructor(node: AST.MustacheStatement, options: {[key: string]: any} = {}) {
     this.node = node;
     this.options = Object.assign({}, defaultOptions, options);
+    this.options.classNameBindings = defaultOptions.classNameBindings.concat(options.classNameBindings || []);
   }
 
   get tagName(): string {

--- a/lib/-private/build-time-component.ts
+++ b/lib/-private/build-time-component.ts
@@ -58,7 +58,7 @@ export default class BuildTimeComponent {
   get attrs(): AST.AttrNode[] {
     let attrs: AST.AttrNode[] = [];
     this.options.attributeBindings.forEach((binding) => {
-      let [propName, attrName] = binding.split(':');
+      let [propName, attrName, valueWhenTrue] = binding.split(':');
       attrName = attrName || propName;
       let attrContent;
       if (this[`${propName}Content`]) {
@@ -74,6 +74,8 @@ export default class BuildTimeComponent {
               attrContent = defaultValue;
             }
           }
+        } else if (pair.value.type === 'PathExpression' && valueWhenTrue) {
+          attrContent = b.mustache(b.path('if'), [pair.value, b.string(valueWhenTrue)])
         } else {
           attrContent = pair.value;
         }

--- a/lib/-private/build-time-component.ts
+++ b/lib/-private/build-time-component.ts
@@ -5,16 +5,16 @@ import {
   AST
 } from '@glimmer/syntax';
 
-export interface BuildTimeComponentOptions {
+export type BuildTimeComponentOptions = {
   tagName: string
   classNames: string[]
   ariaHidden: boolean
   title: string | undefined | null
-  ariaLabel: string | undefined | null,
+  ariaLabel: string | undefined | null
   classNameBindings: string[]
 }
 
-const defaultOptions = {
+const defaultOptions : BuildTimeComponentOptions = {
   tagName: 'div',
   classNames: [],
   ariaHidden: false,
@@ -27,7 +27,7 @@ export default class BuildTimeComponent {
   node: AST.MustacheStatement
   options: BuildTimeComponentOptions
 
-  constructor(node: AST.MustacheStatement, options: {[key: string]: any} = {}) {
+  constructor(node: AST.MustacheStatement, options: Partial<BuildTimeComponentOptions> = {}) {
     this.node = node;
     this.options = Object.assign({}, defaultOptions, options);
     this.options.classNameBindings = defaultOptions.classNameBindings.concat(options.classNameBindings || []);

--- a/lib/-private/build-time-component.ts
+++ b/lib/-private/build-time-component.ts
@@ -6,15 +6,19 @@ import {
 } from '@glimmer/syntax';
 
 export interface BuildTimeComponentOptions {
-  tagName: string,
-  classNames: string[],
+  tagName: string
+  classNames: string[]
   ariaHidden: boolean
+  title: string | undefined | null
+  ariaLabel: string | undefined | null
 }
 
 const defaultOptions = {
   tagName: 'div',
   classNames: [],
-  ariaHidden: false
+  ariaHidden: false,
+  title: undefined,
+  ariaLabel: undefined
 }
 
 export default class BuildTimeComponent {
@@ -38,7 +42,7 @@ export default class BuildTimeComponent {
   }
 
   get attrs(): AST.AttrNode[] {
-    let attrs = [this.classAttr(), this.ariaHiddenAttr()];
+    let attrs = [this.classAttr(), this.ariaHiddenAttr(), this.titleAttr(), this.ariaLabelAttr()];
     return <AST.AttrNode[]> attrs.filter(attr => attr !== null);
   }
 
@@ -67,6 +71,32 @@ export default class BuildTimeComponent {
       content = b.mustache(b.path('if'), [ariaHiddenPair.value, b.string('true')])
     }
     return buildAttr('aria-hidden', content);
+  }
+
+  titleAttr(): AST.AttrNode | null {
+    let content;
+    let titlePair = this.node.hash.pairs.find((pair) => pair.key === 'title');
+    if (titlePair === undefined) {
+      if (this.options.title !== undefined && this.options.title !== null) {
+        content = this.options.title;
+      }
+    } else {
+      content = titlePair.value;
+    }
+    return buildAttr('title', content);
+  }
+
+  ariaLabelAttr(): AST.AttrNode | null {
+    let content;
+    let ariaLabelPair = this.node.hash.pairs.find((pair) => pair.key === 'ariaLabel');
+    if (ariaLabelPair === undefined) {
+      if (this.options.ariaLabel !== undefined && this.options.ariaLabel !== null) {
+        content = this.options.ariaLabel;
+      }
+    } else {
+      content = ariaLabelPair.value;
+    }
+    return buildAttr('aria-label', content);
   }
 
   toNode(): AST.ElementNode {

--- a/lib/-private/build-time-component.ts
+++ b/lib/-private/build-time-component.ts
@@ -1,0 +1,75 @@
+import appendToContent from './append-to-content';
+import buildAttr from './build-attr';
+import {
+  builders as b,
+  AST
+} from '@glimmer/syntax';
+
+export interface BuildTimeComponentOptions {
+  tagName: string,
+  classNames: string[],
+  ariaHidden: boolean
+}
+
+const defaultOptions = {
+  tagName: 'div',
+  classNames: [],
+  ariaHidden: false
+}
+
+export default class BuildTimeComponent {
+  node: AST.MustacheStatement
+  options: BuildTimeComponentOptions
+
+  constructor(node: AST.MustacheStatement, options: object = {}) {
+    this.node = node;
+    this.options = Object.assign({}, defaultOptions, options);
+  }
+
+  get tagName(): string {
+    let tagNamePair = this.node.hash.pairs.find((pair) => pair.key === 'tagName');
+    if (tagNamePair === undefined) {
+      return this.options.tagName;
+    } else if (tagNamePair.value.type === 'StringLiteral') {
+      return tagNamePair.value.value;
+    } else {
+      throw new Error(`Build-time components cannot receive tagName hash properties with type ${tagNamePair.value.type}`);
+    }
+  }
+
+  get attrs(): AST.AttrNode[] {
+    let attrs = [this.classAttr(), this.ariaHiddenAttr()];
+    return <AST.AttrNode[]> attrs.filter(attr => attr !== null);
+  }
+
+  classAttr(): AST.AttrNode | null {
+    let content;
+    if (this.options.classNames.length > 0) {
+      content = appendToContent(this.options.classNames.join(' '), content)
+    }
+    let classPair = this.node.hash.pairs.find((pair) => pair.key === 'class');
+    if (classPair !== undefined) {
+      content = appendToContent(classPair.value, content);
+    }
+    return buildAttr('class', content);
+  }
+
+  ariaHiddenAttr(): AST.AttrNode | null {
+    let content;
+    let ariaHiddenPair = this.node.hash.pairs.find((pair) => pair.key === 'ariaHidden');
+    if (ariaHiddenPair === undefined) {
+      if (this.options.ariaHidden) {
+        content = 'true';
+      }
+    } else if (ariaHiddenPair.value.type === 'BooleanLiteral') {
+      content = ariaHiddenPair.value.value ? 'true' : undefined;
+    } else {
+      content = b.mustache(b.path('if'), [ariaHiddenPair.value, b.string('true')])
+    }
+    return buildAttr('aria-hidden', content);
+  }
+
+  toNode(): AST.ElementNode {
+    return b.element(this.tagName, this.attrs);
+  }
+}

--- a/lib/external-types.d.ts
+++ b/lib/external-types.d.ts
@@ -1,0 +1,3 @@
+declare module 'dashify' {
+  export default function(input: string): string;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,3 +2,4 @@
 
 export { default as buildAttr } from './-private/build-attr';
 export { default as appendToContent } from './-private/append-to-content';
+export { default as BuildTimeComponent } from './-private/build-time-component';

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "eslint-plugin-node": "^5.1.0",
     "glob": "^7.0.0",
     "jest": "^20.0.4",
-    "tslint": "^5.7.0",
     "simple-html-tokenizer": "^0.4.1",
+    "tslint": "^5.7.0",
     "typescript": "^2.5.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "tsc",
-    "test": "jest",
+    "test": "tsc && jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watchAll --notify"
   },

--- a/test/unit/build-attr-test.ts
+++ b/test/unit/build-attr-test.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { builders as b } from '@glimmer/syntax';
+import { builders as b, AST } from '@glimmer/syntax';
 import processTemplate from '../helpers/process-template';
 import { buildAttr } from '../../lib';
 
@@ -97,5 +97,19 @@ describe('Helper #appendToContent', function() {
     });
 
     expect(modifiedTemplate).toEqual(`<div not-class={{concat "a" "b"}}></div>`);
+  });
+
+  it('it builds attrs given a ConcatStatement without superfluous quotes', function() {
+    let modifiedTemplate = processTemplate(`{{some-helper}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'some-helper') {
+          let condition = b.mustache(b.path('if'), [b.path('cond'), b.string('yes'), b.string('no')]);
+          let attr = <AST.AttrNode> buildAttr('not-class', b.concat([condition]));;
+          return b.element('div', [attr]);
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div not-class={{if cond "yes" "no"}}></div>`);
   });
 });

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -1,0 +1,128 @@
+'use strict';
+
+// import { builders as b } from '@glimmer/syntax';
+import processTemplate from '../helpers/process-template';
+import { BuildTimeComponent } from '../../lib';
+
+describe('BuildTimeComponent', function() {
+  // tagName
+  it('generates a div by default', function() {
+    let modifiedTemplate = processTemplate(`{{my-component}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node);
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div></div>`);
+  });
+
+  it('honors the default tagName passed to the constructor', function() {
+    let modifiedTemplate = processTemplate(`{{my-component}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { tagName: 'i' });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<i></i>`);
+  });
+
+  it('honors tagName received over any default', function() {
+    let modifiedTemplate = processTemplate(`{{my-component tagName="span"}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { tagName: 'i' });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<span></span>`);
+  });
+
+  // class
+  it('honors the default classNames passed to the constructor', function() {
+    let modifiedTemplate = processTemplate(`{{my-component}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { classNames: ['foo', 'bar'] });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="foo bar"></div>`);
+  });
+
+  it('concatenates the default classes and the additional strings passed with the `class` option', function() {
+    let modifiedTemplate = processTemplate(`{{my-component class="extra-class"}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNames: ['foo', 'bar'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="foo bar extra-class"></div>`);
+  });
+
+  it('concatenates the default classes and the additional boundValue passed with the `class` option', function() {
+    let modifiedTemplate = processTemplate(`{{my-component class=extraClass}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNames: ['foo', 'bar'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="foo bar {{extraClass}}"></div>`);
+  });
+
+  it('concatenates the default classes and the additional subexpression passed with the `class` option', function() {
+    let modifiedTemplate = processTemplate(`{{my-component class=(concat 'a' 'b')}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNames: ['foo', 'bar'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="foo bar {{concat "a" "b"}}"></div>`);
+  });
+
+  // ariaHidden
+  it('honors the default ariaHidden passed to the constructor', function() {
+    let modifiedTemplate = processTemplate(`{{my-component}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { ariaHidden: true });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div aria-hidden="true"></div>`);
+  });
+
+  it('the boolean passed to ariaHidden trumps over the default value', function() {
+    let modifiedTemplate = processTemplate(`{{my-component ariaHidden=false}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { ariaHidden: true });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div></div>`);
+  });
+
+  it('the path passed to ariaHidden trumps over the default value', function() {
+    let modifiedTemplate = processTemplate(`{{my-component ariaHidden=boundValue}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { ariaHidden: true });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div aria-hidden={{if boundValue "true"}}></div>`);
+  });
+});

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -90,6 +90,113 @@ describe('BuildTimeComponent', function() {
     expect(modifiedTemplate).toEqual(`<div class="foo bar {{concat "a" "b"}}"></div>`);
   });
 
+  // classNameBindings
+  it('transform boolean literals to class names', function() {
+    let modifiedTemplate = processTemplate(`{{my-component isActive=true}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="is-active"></div>`);
+
+    modifiedTemplate = processTemplate(`{{my-component isActive=false}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive'] });
+          return component.toNode();
+        }
+      }
+    });
+    expect(modifiedTemplate).toEqual(`<div></div>`);
+  });
+
+  it('transform paths to class names', function() {
+    let modifiedTemplate = processTemplate(`{{my-component isActive=isActive}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class={{if isActive "is-active"}}></div>`);
+  });
+
+  it('accepts colon syntax to bind attributes to custom classes', function() {
+    let modifiedTemplate = processTemplate(`{{my-component isActive=true}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive:on-duty'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="on-duty"></div>`);
+
+    modifiedTemplate = processTemplate(`{{my-component isActive=false}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive:on-duty'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div></div>`);
+
+    modifiedTemplate = processTemplate(`{{my-component isActive=isActive}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive:on-duty'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class={{if isActive 'on-duty'}}></div>`);
+  });
+
+  it('accepts colon syntax to bind attributes to custom classes and its opposite', function() {
+    let modifiedTemplate = processTemplate(`{{my-component isActive=true}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive:on-duty:reservist'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class="on-duty"></div>`);
+
+    modifiedTemplate = processTemplate(`{{my-component isActive=false}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive:on-duty:reservist'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div></div>`);
+
+    modifiedTemplate = processTemplate(`{{my-component isActive=isActive}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { classNameBindings: ['isActive:on-duty:reservist'] });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div class={{if isActive 'on-duty'}}></div>`);
+  });
+
   // ariaHidden
   it('honors the default ariaHidden passed to the constructor', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -1,11 +1,10 @@
 'use strict';
 
-// import { builders as b } from '@glimmer/syntax';
 import processTemplate from '../helpers/process-template';
 import { BuildTimeComponent } from '../../lib';
 
 describe('BuildTimeComponent', function() {
-  // // tagName
+  // tagName
   it('generates a div by default', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {
       MustacheStatement(node) {
@@ -201,7 +200,10 @@ describe('BuildTimeComponent', function() {
   it('honors the default ariaHidden passed to the constructor', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {
       MustacheStatement(node) {
-        let component = new BuildTimeComponent(node, { ariaHidden: true });
+        let component = new BuildTimeComponent(node, {
+          ariaHidden: true,
+          attributeBindings: ['ariaHidden:aria-hidden']
+        });
         return component.toNode();
       }
     });
@@ -212,7 +214,10 @@ describe('BuildTimeComponent', function() {
   it('the boolean passed to ariaHidden trumps over the default value', function() {
     let modifiedTemplate = processTemplate(`{{my-component ariaHidden=false}}`, {
       MustacheStatement(node) {
-        let component = new BuildTimeComponent(node, { ariaHidden: true });
+        let component = new BuildTimeComponent(node, {
+          ariaHidden: true,
+          attributeBindings: ['ariaHidden:aria-hidden']
+        });
         return component.toNode();
       }
     });
@@ -224,20 +229,26 @@ describe('BuildTimeComponent', function() {
     let modifiedTemplate = processTemplate(`{{my-component ariaHidden=boundValue}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-component') {
-          let component = new BuildTimeComponent(node, { ariaHidden: true });
+          let component = new BuildTimeComponent(node, {
+            ariaHidden: true,
+            attributeBindings: ['ariaHidden:aria-hidden']
+          });
           return component.toNode();
         }
       }
     });
 
-    expect(modifiedTemplate).toEqual(`<div aria-hidden={{if boundValue "true"}}></div>`);
+    expect(modifiedTemplate).toEqual(`<div aria-hidden={{boundValue}}></div>`);
   });
 
   // ariaLabel
   it('honors the default ariaLabel passed to the constructor', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {
       MustacheStatement(node) {
-        let component = new BuildTimeComponent(node, { ariaLabel: 'sample ariaLabel' });
+        let component = new BuildTimeComponent(node, {
+          ariaLabel: 'sample ariaLabel',
+          attributeBindings: ['ariaLabel:aria-label']
+        });
         return component.toNode();
       }
     });
@@ -248,7 +259,10 @@ describe('BuildTimeComponent', function() {
   it('the boolean passed to ariaLabel trumps over the default value', function() {
     let modifiedTemplate = processTemplate(`{{my-component ariaLabel="other ariaLabel"}}`, {
       MustacheStatement(node) {
-        let component = new BuildTimeComponent(node, { ariaLabel: 'sample ariaLabel' });
+        let component = new BuildTimeComponent(node, {
+          ariaLabel: 'sample ariaLabel',
+          attributeBindings: ['ariaLabel:aria-label']
+        });
         return component.toNode();
       }
     });
@@ -260,7 +274,10 @@ describe('BuildTimeComponent', function() {
     let modifiedTemplate = processTemplate(`{{my-component ariaLabel=boundValue}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-component') {
-          let component = new BuildTimeComponent(node, { ariaLabel: 'default aria label' });
+          let component = new BuildTimeComponent(node, {
+            ariaLabel: 'default aria label',
+            attributeBindings: ['ariaLabel:aria-label']
+          });
           return component.toNode();
         }
       }
@@ -273,7 +290,7 @@ describe('BuildTimeComponent', function() {
   it('honors the default title passed to the constructor', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {
       MustacheStatement(node) {
-        let component = new BuildTimeComponent(node, { title: 'sample title' });
+        let component = new BuildTimeComponent(node, { title: 'sample title', attributeBindings: ['title'] });
         return component.toNode();
       }
     });
@@ -284,7 +301,7 @@ describe('BuildTimeComponent', function() {
   it('the boolean passed to title trumps over the default value', function() {
     let modifiedTemplate = processTemplate(`{{my-component title="other title"}}`, {
       MustacheStatement(node) {
-        let component = new BuildTimeComponent(node, { title: 'sample title' });
+        let component = new BuildTimeComponent(node, { title: 'sample title', attributeBindings: ['title'] });
         return component.toNode();
       }
     });
@@ -296,7 +313,7 @@ describe('BuildTimeComponent', function() {
     let modifiedTemplate = processTemplate(`{{my-component title=boundValue}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-component') {
-          let component = new BuildTimeComponent(node, { title: 'default title' });
+          let component = new BuildTimeComponent(node, { title: 'default title', attributeBindings: ['title'] });
           return component.toNode();
         }
       }

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -5,7 +5,7 @@ import processTemplate from '../helpers/process-template';
 import { BuildTimeComponent } from '../../lib';
 
 describe('BuildTimeComponent', function() {
-  // tagName
+  // // tagName
   it('generates a div by default', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {
       MustacheStatement(node) {
@@ -159,7 +159,7 @@ describe('BuildTimeComponent', function() {
       }
     });
 
-    expect(modifiedTemplate).toEqual(`<div class={{if isActive 'on-duty'}}></div>`);
+    expect(modifiedTemplate).toEqual(`<div class={{if isActive "on-duty"}}></div>`);
   });
 
   it('accepts colon syntax to bind attributes to custom classes and its opposite', function() {
@@ -183,7 +183,7 @@ describe('BuildTimeComponent', function() {
       }
     });
 
-    expect(modifiedTemplate).toEqual(`<div></div>`);
+    expect(modifiedTemplate).toEqual(`<div class="reservist"></div>`);
 
     modifiedTemplate = processTemplate(`{{my-component isActive=isActive}}`, {
       MustacheStatement(node) {
@@ -194,7 +194,7 @@ describe('BuildTimeComponent', function() {
       }
     });
 
-    expect(modifiedTemplate).toEqual(`<div class={{if isActive 'on-duty'}}></div>`);
+    expect(modifiedTemplate).toEqual(`<div class={{if isActive "on-duty" "reservist"}}></div>`);
   });
 
   // ariaHidden

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -125,4 +125,76 @@ describe('BuildTimeComponent', function() {
 
     expect(modifiedTemplate).toEqual(`<div aria-hidden={{if boundValue "true"}}></div>`);
   });
+
+  // ariaLabel
+  it('honors the default ariaLabel passed to the constructor', function() {
+    let modifiedTemplate = processTemplate(`{{my-component}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { ariaLabel: 'sample ariaLabel' });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div aria-label="sample ariaLabel"></div>`);
+  });
+
+  it('the boolean passed to ariaLabel trumps over the default value', function() {
+    let modifiedTemplate = processTemplate(`{{my-component ariaLabel="other ariaLabel"}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { ariaLabel: 'sample ariaLabel' });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div aria-label="other ariaLabel"></div>`);
+  });
+
+  it('the path passed to ariaLabel trumps over the default value', function() {
+    let modifiedTemplate = processTemplate(`{{my-component ariaLabel=boundValue}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { ariaLabel: true });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div aria-label={{boundValue}}></div>`);
+  });
+
+  // title
+  it('honors the default title passed to the constructor', function() {
+    let modifiedTemplate = processTemplate(`{{my-component}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { title: 'sample title' });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div title="sample title"></div>`);
+  });
+
+  it('the boolean passed to title trumps over the default value', function() {
+    let modifiedTemplate = processTemplate(`{{my-component title="other title"}}`, {
+      MustacheStatement(node) {
+        let component = new BuildTimeComponent(node, { title: 'sample title' });
+        return component.toNode();
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div title="other title"></div>`);
+  });
+
+  it('the path passed to title trumps over the default value', function() {
+    let modifiedTemplate = processTemplate(`{{my-component title=boundValue}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, { title: true });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div title={{boundValue}}></div>`);
+  });
 });

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -260,7 +260,7 @@ describe('BuildTimeComponent', function() {
     let modifiedTemplate = processTemplate(`{{my-component ariaLabel=boundValue}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-component') {
-          let component = new BuildTimeComponent(node, { ariaLabel: true });
+          let component = new BuildTimeComponent(node, { ariaLabel: 'default aria label' });
           return component.toNode();
         }
       }
@@ -296,7 +296,7 @@ describe('BuildTimeComponent', function() {
     let modifiedTemplate = processTemplate(`{{my-component title=boundValue}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-component') {
-          let component = new BuildTimeComponent(node, { title: true });
+          let component = new BuildTimeComponent(node, { title: 'default title' });
           return component.toNode();
         }
       }

--- a/test/unit/build-time-component-test.ts
+++ b/test/unit/build-time-component-test.ts
@@ -241,6 +241,22 @@ describe('BuildTimeComponent', function() {
     expect(modifiedTemplate).toEqual(`<div aria-hidden={{boundValue}}></div>`);
   });
 
+  it('the path passed to ariaHidden trumps over the default value and uses the true value when provided', function() {
+    let modifiedTemplate = processTemplate(`{{my-component ariaHidden=boundValue}}`, {
+      MustacheStatement(node) {
+        if (node.path.original === 'my-component') {
+          let component = new BuildTimeComponent(node, {
+            ariaHidden: true,
+            attributeBindings: ['ariaHidden:aria-hidden:secret']
+          });
+          return component.toNode();
+        }
+      }
+    });
+
+    expect(modifiedTemplate).toEqual(`<div aria-hidden={{if boundValue "secret"}}></div>`);
+  });
+
   // ariaLabel
   it('honors the default ariaLabel passed to the constructor', function() {
     let modifiedTemplate = processTemplate(`{{my-component}}`, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,10 @@
   version "20.0.8"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.8.tgz#7f8c97f73d20d3bf5448fbe33661a342002b5954"
 
+"@types/string@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/string/-/string-0.0.29.tgz#9b6de0ec6884bdbe9520a0e4022886b57759f5fa"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -486,6 +490,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+dashify@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dashify/-/dashify-0.2.2.tgz#6a07415a01c91faf4a32e38d9dfba71f61cb20fe"
 
 debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
@@ -1833,6 +1841,10 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+string@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
 stringstream@~0.0.4:
   version "0.0.5"


### PR DESCRIPTION
This should be the abstraction people use most of the time to create compile-time components.

It tried to resemble `Ember.Component` to feel familiar to developers, but only in the surface.

Some complex usages:

```js
const { BuildTimeComponent } = require('ember-ast-helpers');
//...
traverse(ast, {
  MustacheStatement(node) {
    if (node.path.original === 'my-target-component') {
      let component = new BuildTimeComponent(node, {
        tagName: 'span',
        classNameBindings: ['active:is-active:disabled', 'isImportant'],
        attributeBindings: ['title', 'ariaLabel:aria-label'],
        classNames: ['my-target', 'another-class'],
        title: 'default title'
      });
      return component.toNode(); // This is what actually generates the result
    }
  }
}) 
```

The idea is that it will also allow users to create something similar to computed properties using ES5 getters and subclassing. By example, a component in which the `aria-label` matches the `title`.

```js
const { BuildTimeComponent } = require('ember-ast-helpers');

class MyTargetComponent extends BuildTimeComponent {
  constructor(node, opts) {
    opts.classNameBindings = opts.classNameBindings || [];
    // set some default opts before calling super
    opts.classNameBindings.push('title');
    opts.classNameBindings.push('ariaLabel:aria-label');
    super(node, opts);
  }

  get ariaLabelContent() {
    // use this special getter named `<propertyName>Content` to
    // customize the value of the `aria-label`. By example in where you
    // could make it be an alias of the title
  }
}

traverse(ast, {
  MustacheStatement(node) {
    if (node.path.original === 'my-targe-component') {
      let myTargetComponent = new MyTargetComponent(node, { more: 'options' });
      myTargetComponent.toNode();
    }
  }
}) 
```

Still very much a WIP, but I think this is the right abstraction.