### PR TITLE
Add option to `interpolateProperties` to wrap interpolation in helper

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
Example:
```hbs
{{fa-icon color=boundColor}}
```
```js
class FaIcon extends BuildTimeComponent {
  constructor() {
    super(...arguments);
    this.styleContent = interpolateProperties('color:$color$', { divisor: '$', skipIfMissingDynamic: true });
  }
}
```
```html
<i class="fa" style={{if color (concat "color:" color)}}></i>
```

This option by default is false, because it's a rather convoluted output for what is usually an uncommon
use case (so I think, time will tell)