### PR TITLE
Avoid importing stuff from @glimmer/syntax

### DIFF
--- a/lib/build-time-component.ts
+++ b/lib/build-time-component.ts
@@ -164,11 +164,11 @@ export default class BuildTimeComponent {
   classContent(): BuildAttrContent | undefined {
     let content: AST.AttrNode['value'] | undefined;
     if (this.classNames.length > 0) {
-      content = appendToAttrContent(this.classNames.join(' '))
+      content = appendToAttrContent(b, this.classNames.join(' '))
     }
     content = this._applyClassNameBindings(content);
     if (this.invocationAttrs.class !== undefined) {
-      content = appendToAttrContent(this.invocationAttrs.class, content);
+      content = appendToAttrContent(b, this.invocationAttrs.class, content);
     }
     return content;
   }
@@ -236,7 +236,7 @@ export default class BuildTimeComponent {
       } else {
         content = computedValue || invocationValue || staticValue;
       }
-      let attr = buildAttr(<string>attrName, content);
+      let attr = buildAttr(b, <string>attrName, content);
       if (attr !== null) {
         attrs.push(attr);
       }
@@ -358,22 +358,22 @@ export default class BuildTimeComponent {
         if (computedValue !== undefined) {
           let part = computedValue ? truthyValue : falsyValue;
           if (part) {
-            content = appendToAttrContent(part, content);
+            content = appendToAttrContent(b, part, content);
           }
         } else if (invocationValue !== undefined) {
           if (AST.isLiteral(invocationValue)) {
             let part = invocationValue.value ? truthyValue : falsyValue;
             if (part) {
-              content = appendToAttrContent(part, content);
+              content = appendToAttrContent(b, part, content);
             }
           } else {
-            content = appendToAttrContent(buildConditional(invocationValue, truthyValue, falsyValue), content)
+            content = appendToAttrContent(b, buildConditional(invocationValue, truthyValue, falsyValue), content)
           }
         } else {
-          content = appendToAttrContent(staticValue ? truthyValue : falsyValue, content);
+          content = appendToAttrContent(b, staticValue ? truthyValue : falsyValue, content);
         }
       } else {
-        content = appendToAttrContent(computedValue || invocationValue || staticValue, content);
+        content = appendToAttrContent(b, computedValue || invocationValue || staticValue, content);
       }
     });
     return content;

--- a/lib/build-time-component/interpolate-properties.ts
+++ b/lib/build-time-component/interpolate-properties.ts
@@ -89,7 +89,7 @@ export default function interpolateProperties(interpolation: string, { divisor =
           }
         }
       }
-      return buildAttrContent(concatParts);
+      return buildAttrContent(b, concatParts);
     }
   }
 }

--- a/test/unit/html/append-to-attr-content-test.ts
+++ b/test/unit/html/append-to-attr-content-test.ts
@@ -8,8 +8,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append undefined (which does nothing)', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(undefined, attr.value);
-        attr.value = appendToAttrContent(undefined, attr.value);
+        attr.value = appendToAttrContent(b, undefined, attr.value);
+        attr.value = appendToAttrContent(b, undefined, attr.value);
         return attr;
       }
     });
@@ -20,8 +20,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append null (which does nothing)', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(null, attr.value);
-        attr.value = appendToAttrContent(null, attr.value);
+        attr.value = appendToAttrContent(b, null, attr.value);
+        attr.value = appendToAttrContent(b, null, attr.value);
         return attr;
       }
     });
@@ -32,8 +32,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append regular strings', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent('bar', attr.value);
-        attr.value = appendToAttrContent('baz', attr.value);
+        attr.value = appendToAttrContent(b, 'bar', attr.value);
+        attr.value = appendToAttrContent(b, 'baz', attr.value);
         return attr;
       }
     });
@@ -44,8 +44,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append StringLiterals', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.string('bar'), attr.value);
-        attr.value = appendToAttrContent(b.string('baz'), attr.value);
+        attr.value = appendToAttrContent(b, b.string('bar'), attr.value);
+        attr.value = appendToAttrContent(b, b.string('baz'), attr.value);
         return attr;
       }
     });
@@ -56,8 +56,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append NumberLiterals', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.number(1), attr.value);
-        attr.value = appendToAttrContent(b.number(2), attr.value);
+        attr.value = appendToAttrContent(b, b.number(1), attr.value);
+        attr.value = appendToAttrContent(b, b.number(2), attr.value);
         return attr;
       }
     });
@@ -68,8 +68,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append TextNodes to another TextNode', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.text('bar'), attr.value);
-        attr.value = appendToAttrContent(b.text('baz'), attr.value);
+        attr.value = appendToAttrContent(b, b.text('bar'), attr.value);
+        attr.value = appendToAttrContent(b, b.text('baz'), attr.value);
         return attr;
       }
     });
@@ -80,8 +80,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append PathExpression', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.path('bar'), attr.value);
-        attr.value = appendToAttrContent(b.path('baz'), attr.value);
+        attr.value = appendToAttrContent(b, b.path('bar'), attr.value);
+        attr.value = appendToAttrContent(b, b.path('baz'), attr.value);
         return attr;
       }
     });
@@ -92,9 +92,9 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append MustacheStatement containing paths', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.mustache(b.path('bar')), attr.value);
-        attr.value = appendToAttrContent(b.mustache(b.path('baz')), attr.value);
-        attr.value = appendToAttrContent(b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.path('bar')), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.path('baz')), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
         return attr;
       }
     });
@@ -105,9 +105,9 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append MustacheStatement containing StringLiterals', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.mustache(b.string('bar')), attr.value);
-        attr.value = appendToAttrContent(b.mustache(b.string('baz')), attr.value);
-        attr.value = appendToAttrContent(b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.string('bar')), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.string('baz')), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
         return attr;
       }
     });
@@ -118,8 +118,8 @@ describe('Helper #appendToAttrContent', function() {
   it('it can append SubExpressions', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.sexpr(b.path('some-helper'), [b.string('someArg')]), attr.value);
-        attr.value = appendToAttrContent(b.sexpr(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
+        attr.value = appendToAttrContent(b, b.sexpr(b.path('some-helper'), [b.string('someArg')]), attr.value);
+        attr.value = appendToAttrContent(b, b.sexpr(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
         return attr;
       }
     });
@@ -131,9 +131,9 @@ describe('Helper #appendToAttrContent', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
         let val = b.concat([b.text('prefix'), b.mustache(b.path('boundVal')), b.text('suffix')]);
-        attr.value = appendToAttrContent(val, attr.value);
+        attr.value = appendToAttrContent(b, val, attr.value);
         let val2 = b.concat([b.text('prefix2'), b.mustache(b.path('boundVal2'))]);
-        attr.value = appendToAttrContent(val2, attr.value);
+        attr.value = appendToAttrContent(b, val2, attr.value);
         return attr;
       }
     });
@@ -144,14 +144,14 @@ describe('Helper #appendToAttrContent', function() {
   it('it can mix and append a mix of elements', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.mustache(b.path('one')), b.text(''));
-        attr.value = appendToAttrContent(b.mustache(b.path('two')), attr.value);
-        attr.value = appendToAttrContent(b.text('three'), attr.value);
-        attr.value = appendToAttrContent('four', attr.value);
-        attr.value = appendToAttrContent(b.path('five'), attr.value);
-        attr.value = appendToAttrContent(b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
-        attr.value = appendToAttrContent(b.path('six'), attr.value);
-        attr.value = appendToAttrContent(b.concat([b.mustache(b.path('sev')), b.text('en')]), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.path('one')), b.text(''));
+        attr.value = appendToAttrContent(b, b.mustache(b.path('two')), attr.value);
+        attr.value = appendToAttrContent(b, b.text('three'), attr.value);
+        attr.value = appendToAttrContent(b, 'four', attr.value);
+        attr.value = appendToAttrContent(b, b.path('five'), attr.value);
+        attr.value = appendToAttrContent(b, b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value);
+        attr.value = appendToAttrContent(b, b.path('six'), attr.value);
+        attr.value = appendToAttrContent(b, b.concat([b.mustache(b.path('sev')), b.text('en')]), attr.value);
         return attr;
       }
     });
@@ -162,14 +162,14 @@ describe('Helper #appendToAttrContent', function() {
   it('it can mix and append a mix of elements without prepending spaces', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode(attr) {
-        attr.value = appendToAttrContent(b.mustache(b.path('one')), b.text(''), { prependSpace: false });
-        attr.value = appendToAttrContent(b.mustache(b.path('two')), attr.value, { prependSpace: false });
-        attr.value = appendToAttrContent(b.text('three'), attr.value, { prependSpace: false });
-        attr.value = appendToAttrContent('four', attr.value, { prependSpace: false });
-        attr.value = appendToAttrContent(b.path('five'), attr.value, { prependSpace: false });
-        attr.value = appendToAttrContent(b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value, { prependSpace: false });
-        attr.value = appendToAttrContent(b.path('six'), attr.value, { prependSpace: false });
-        attr.value = appendToAttrContent(b.concat([b.mustache(b.path('sev')), b.text('en')]), attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.mustache(b.path('one')), b.text(''), { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.mustache(b.path('two')), attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.text('three'), attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, 'four', attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.path('five'), attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.mustache(b.path('if'), [b.path('condition'), b.string('yes'), b.string('no')]), attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.path('six'), attr.value, { prependSpace: false });
+        attr.value = appendToAttrContent(b, b.concat([b.mustache(b.path('sev')), b.text('en')]), attr.value, { prependSpace: false });
         return attr;
       }
     });

--- a/test/unit/html/build-attr-content-test.ts
+++ b/test/unit/html/build-attr-content-test.ts
@@ -10,7 +10,7 @@ describe('Helper #buildToAttrContent', function() {
     let modifiedTemplate = processTemplate(`{{my-foo}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-foo') {
-          attrContent = buildAttrContent([
+          attrContent = buildAttrContent(b, [
             'rawstring',
             1,
             b.string('StringLiteral'),
@@ -21,7 +21,7 @@ describe('Helper #buildToAttrContent', function() {
             b.text('TextNode'),
             b.sexpr(b.path('concat'), [b.path('firstName'), b.path('lastName')]),
           ]);
-          let attr = buildAttr('class', attrContent);
+          let attr = buildAttr(b, 'class', attrContent);
           let attrs = attr ? [attr] : [];
           return b.element('div', attrs);
         }
@@ -37,7 +37,7 @@ describe('Helper #buildToAttrContent', function() {
     let modifiedTemplate = processTemplate(`{{my-foo}}`, {
       MustacheStatement(node) {
         if (node.path.original === 'my-foo') {
-          attrContent = buildAttrContent([
+          attrContent = buildAttrContent(b, [
             'rawstring',
             1,
             b.string('StringLiteral'),
@@ -48,7 +48,7 @@ describe('Helper #buildToAttrContent', function() {
             'LastString'
           ]);
 
-          let attr = buildAttr('class', attrContent);
+          let attr = buildAttr(b, 'class', attrContent);
           let attrs = attr ? [attr] : [];
           return b.element('div', attrs);
         }

--- a/test/unit/html/build-attr-test.ts
+++ b/test/unit/html/build-attr-test.ts
@@ -8,7 +8,7 @@ describe('Helper #appendToContent', function() {
   it('it builds attrs given a string', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', 'new content');
+        return buildAttr(b, 'not-class', 'new content');
       }
     });
 
@@ -18,7 +18,7 @@ describe('Helper #appendToContent', function() {
   it('it builds attrs given a TextNode', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.text('new content'));
+        return buildAttr(b, 'not-class', b.text('new content'));
       }
     });
 
@@ -28,7 +28,7 @@ describe('Helper #appendToContent', function() {
   it('it builds attrs given a StringLiteral', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.string('new content'));
+        return buildAttr(b, 'not-class', b.string('new content'));
       }
     });
 
@@ -38,7 +38,7 @@ describe('Helper #appendToContent', function() {
   it('it builds attrs given a BooleanLiteral', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.boolean(true));
+        return buildAttr(b, 'not-class', b.boolean(true));
       }
     });
 
@@ -46,7 +46,7 @@ describe('Helper #appendToContent', function() {
 
     modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.boolean(false));
+        return buildAttr(b, 'not-class', b.boolean(false));
       }
     });
 
@@ -56,7 +56,7 @@ describe('Helper #appendToContent', function() {
   it('it builds attrs given a NumberLiteral', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.number(2));
+        return buildAttr(b, 'not-class', b.number(2));
       }
     });
 
@@ -64,7 +64,7 @@ describe('Helper #appendToContent', function() {
 
     modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.boolean(false));
+        return buildAttr(b, 'not-class', b.boolean(false));
       }
     });
 
@@ -74,7 +74,7 @@ describe('Helper #appendToContent', function() {
   it('it builds attrs given a PathExpression', function() {
     let modifiedTemplate = processTemplate(`<div class="foo"></div>`, {
       AttrNode() {
-        return buildAttr('not-class', b.path('boundValue'));
+        return buildAttr(b, 'not-class', b.path('boundValue'));
       }
     });
 
@@ -87,7 +87,7 @@ describe('Helper #appendToContent', function() {
         let title = node.hash.pairs.filter((p) => p.key === 'title')[0];
         if (title !== undefined) {
           let attrs = [];
-          let attr = buildAttr('not-class', title.value);
+          let attr = buildAttr(b, 'not-class', title.value);
           if (attr) {
             attrs.push(attr)
           }
@@ -104,7 +104,7 @@ describe('Helper #appendToContent', function() {
       MustacheStatement(node) {
         if (node.path.original === 'some-helper') {
           let condition = b.mustache(b.path('if'), [b.path('cond'), b.string('yes'), b.string('no')]);
-          let attr = <AST.AttrNode> buildAttr('not-class', b.concat([condition]));;
+          let attr = <AST.AttrNode> buildAttr(b, 'not-class', b.concat([condition]));;
           return b.element('div', [attr]);
         }
       }


### PR DESCRIPTION
The syntax should be passed from the outside, not imported, to avoid
depending on a different version of glimmer than the consuming app.